### PR TITLE
Fix namespacing error in Error class

### DIFF
--- a/latch/includes/latchSDK/LatchError.php
+++ b/latch/includes/latchSDK/LatchError.php
@@ -20,7 +20,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-class Error {
+class LatchError {
 	private $code;
 	private $message;
 	

--- a/latch/includes/latchSDK/LatchResponse.php
+++ b/latch/includes/latchSDK/LatchResponse.php
@@ -20,7 +20,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-require_once("Error.php");
+require_once("LatchError.php");
 
 /**
  * This class models a response from any of the endpoints in the Latch API.
@@ -47,7 +47,7 @@ class LatchResponse {
 				$this->data = $json->{"data"};
 			}
 			if (array_key_exists("error", $json)) {
-				$this->error = new Error($json->{"error"});
+				$this->error = new LatchError($json->{"error"});
 			} 
 		}
 	}
@@ -81,7 +81,7 @@ class LatchResponse {
 	 * @param $error an error to include in the API response
 	 */
 	public function setError($error) {
-		$this->error = new Error($error);
+		$this->error = new LatchError($error);
 	}
 
 	/**


### PR DESCRIPTION
### What

An error happens when installing the latch plugin following the instructions in the Readme:

`Error: Cannot declare class Error, because the name is already in use in /var/www/kimball/sites/all/modules/latch-plugin-drupal7/latch/includes/latchSDK/Error.php, line 23`

Using: `PHP 7.0.30-0ubuntu0.16.04.1`

This error seems to happen because of a collision with another class named `Error`.

### How

This issue gets fixed renaming the class to `LatchError`